### PR TITLE
fix(vault): Using new methods in vaulty after deprication of generated methods

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -19,7 +19,7 @@ func getVaultClient(v *viper.Viper) (*api.Client, error) {
 	}
 
 	vc, err := vaulty.NewClient(
-		vaulty.WithGeneratedVaultClient(addr),
+		vaulty.WithAddr(addr),
 		vaulty.WithKubernetesAuthDefault(),
 	)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->
Using new methods in vaulty after deprication of `WithGeneratedVaultClient` method.