### PR TITLE
feat(cicd): Adding additional linters

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -47,7 +47,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          only-new-issues: true
           args: --verbose --timeout 5m
 
   code-approval:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,143 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - revive
+      text: "^(enforce-slice-style|enforce-map-style)"
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.

--- a/consts.go
+++ b/consts.go
@@ -5,11 +5,12 @@ const (
 
 	loggingKeyAppName = "app"
 	loggingKeyError   = "err"
+	loggingKeySignal  = "signal"
 
 	defaultKubeConfigLocation     = "$HOME/.kube/config"
 	defaultRefreshIntervalSeconds = 30
 	defaultVaultAddr              = "http://vault-active.vault.svc.cluster.local:8200"
 
-	secretAnnotationKey  = "vault-sync-id"
+	secretAnnotationKey  = "vault-sync-id" // nolint:gosec // This is not a credential
 	secretLabelManagedBy = "managed-by"
 )

--- a/consts.go
+++ b/consts.go
@@ -6,6 +6,7 @@ const (
 	loggingKeyAppName = "app"
 	loggingKeyError   = "err"
 	loggingKeySignal  = "signal"
+	loggingKeyAddr    = "addr"
 
 	defaultKubeConfigLocation     = "$HOME/.kube/config"
 	defaultRefreshIntervalSeconds = 30

--- a/consts.go
+++ b/consts.go
@@ -3,10 +3,12 @@ package main
 const (
 	appName = "secret-sync"
 
-	loggingKeyAppName = "app"
-	loggingKeyError   = "err"
-	loggingKeySignal  = "signal"
-	loggingKeyAddr    = "addr"
+	loggingKeyAppName     = "app"
+	loggingKeyError       = "err"
+	loggingKeySignal      = "signal"
+	loggingKeyAddr        = "addr"
+	loggingKeyNamespace   = "namespace"
+	loggingKeyDestination = "destination"
 
 	defaultKubeConfigLocation     = "$HOME/.kube/config"
 	defaultRefreshIntervalSeconds = 30

--- a/context.go
+++ b/context.go
@@ -16,7 +16,7 @@ func getRootContext() context.Context {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 		got := <-sig
-		slog.Info("Received signal, shutting down", slog.String("signal", got.String()))
+		slog.Info("Received signal, shutting down", slog.String(loggingKeySignal, got.String()))
 		cancel()
 	}()
 

--- a/hashing.go
+++ b/hashing.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 )
 
 func shaHash(data []byte) string {
-	hasher := sha1.New()
+	hasher := sha256.New()
 	hasher.Write(data)
 	return fmt.Sprintf("%x", hasher.Sum(nil))
 }

--- a/logging.go
+++ b/logging.go
@@ -14,7 +14,7 @@ func initializeLogger() {
 	}))
 
 	logger.With(
-		loggingKeyAppName, appName,
+		slog.String(loggingKeyAppName, appName),
 	)
 
 	slog.SetDefault(logger)
@@ -22,8 +22,7 @@ func initializeLogger() {
 
 // replaceLogAttrs is a slog.HandlerOptions.ReplaceAttr function that replaces some attributes.
 func replaceLogAttrs(_ []string, a slog.Attr) slog.Attr {
-	switch a.Key {
-	case slog.SourceKey:
+	if a.Key == slog.SourceKey {
 		// Cut the source file to a relative path.
 		v := strings.Split(a.Value.String(), "/")
 		idx := len(v) - 2

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func (a *app) Start() {
 			Handler:           r,
 		}
 		slog.Info("Starting metrics server")
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) { // nolint:revive // Traditional error handling
 			slog.Error("Error starting metrics server", slog.String(loggingKeyError, err.Error()))
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -50,8 +50,9 @@ func (a *app) Start() {
 		r := mux.NewRouter()
 		r.HandleFunc("/metrics", promhttp.Handler().ServeHTTP)
 		srv := &http.Server{
-			Addr:    ":8080",
-			Handler: r,
+			Addr:              ":8080",
+			ReadHeaderTimeout: 10 * time.Second,
+			Handler:           r,
 		}
 		slog.Info("Starting metrics server")
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/sync.go
+++ b/sync.go
@@ -98,7 +98,7 @@ func (a *app) syncSecrets() {
 				slog.Error("Error getting secret", slog.String(loggingKeyError, err.Error()))
 				return
 			} else if foundSecret.Namespace != s.DestinationNamespace {
-				slog.Info("Secret exists in a different namespace", slog.String("namespace", foundSecret.Namespace))
+				slog.Info("Secret exists in a different namespace", slog.String(loggingKeyNamespace, foundSecret.Namespace))
 
 				// Delete the secret
 				if err := a.client.CoreV1().Secrets(ns.Name).Delete(a.ctx, foundSecret.Namespace, metav1.DeleteOptions{}); err != nil {

--- a/sync.go
+++ b/sync.go
@@ -23,15 +23,16 @@ type secret struct {
 }
 
 func (s *secret) Valid() error {
-	if s.Path == "" {
+	switch {
+	case s.Path == "":
 		return ErrNoPath
-	} else if s.DestinationNamespace == "" {
+	case s.DestinationNamespace == "":
 		return ErrNoDestinationNamespace
-	} else if s.DestinationName == "" {
+	case s.DestinationName == "":
 		return ErrNoDestinationName
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 func (a *app) watchSecrets() {
@@ -78,7 +79,9 @@ func (a *app) syncSecrets() {
 		}
 
 		secretFound := false
-		for _, ns := range namespaces.Items {
+		for i := range namespaces.Items {
+			ns := &namespaces.Items[i] // Make the app less memory intensive
+
 			// Does the secret exist in this namespace?
 			foundSecret, err := a.client.CoreV1().Secrets(ns.Name).Get(a.ctx, s.DestinationName, metav1.GetOptions{
 				TypeMeta: metav1.TypeMeta{
@@ -87,7 +90,7 @@ func (a *app) syncSecrets() {
 			})
 			if err != nil {
 				newErr := new(coreErr.StatusError)
-				if errors.As(err, &newErr) && newErr.ErrStatus.Reason == metav1.StatusReasonNotFound {
+				if newErr.ErrStatus.Reason == metav1.StatusReasonNotFound && errors.As(err, &newErr) {
 					// Secret does not exist in this namespace
 					continue
 				}

--- a/task_create_secret.go
+++ b/task_create_secret.go
@@ -92,5 +92,8 @@ func (t *taskCreateSecret) Run() {
 		return
 	}
 
-	slog.Debug("Secret created successfully", slog.String("namespace", t.s.DestinationNamespace), slog.String("name", t.s.DestinationName))
+	slog.Debug("Secret created successfully",
+		slog.String(loggingKeyNamespace, t.s.DestinationNamespace),
+		slog.String(loggingKeyDestination, t.s.DestinationName),
+	)
 }

--- a/task_create_secret.go
+++ b/task_create_secret.go
@@ -40,7 +40,7 @@ func (t *taskCreateSecret) Run() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        t.s.DestinationName,
 			Namespace:   t.s.DestinationNamespace,
-			Annotations: map[string]string{},
+			Annotations: make(map[string]string),
 			Labels: map[string]string{
 				secretLabelManagedBy: appName,
 			},
@@ -66,7 +66,7 @@ func (t *taskCreateSecret) Run() {
 			continue
 		}
 
-		m, ok := vv.(map[string]interface{})
+		m, ok := vv.(map[string]any)
 		if !ok {
 			slog.Error("Error casting secret data to map[string]interface{}")
 			return

--- a/task_update_secret.go
+++ b/task_update_secret.go
@@ -83,7 +83,10 @@ func (t *taskUpdateSecret) Run() {
 		}
 	} else if existingSecret.Annotations[secretAnnotationKey] == hash &&
 		(existingSecret.Labels != nil && existingSecret.Labels[secretLabelManagedBy] == appName) {
-		slog.Debug("Secret is up to date", slog.String("namespace", t.s.DestinationNamespace), slog.String("name", t.s.DestinationName))
+		slog.Debug("Secret is up to date",
+			slog.String(loggingKeyNamespace, t.s.DestinationNamespace),
+			slog.String(loggingKeyDestination, t.s.DestinationName),
+		)
 		return
 	}
 
@@ -95,5 +98,8 @@ func (t *taskUpdateSecret) Run() {
 		return
 	}
 
-	slog.Debug("Secret updated successfully", slog.String("namespace", t.s.DestinationNamespace), slog.String("name", t.s.DestinationName))
+	slog.Debug("Secret updated successfully",
+		slog.String(loggingKeyNamespace, t.s.DestinationNamespace),
+		slog.String(loggingKeyDestination, t.s.DestinationName),
+	)
 }

--- a/task_update_secret.go
+++ b/task_update_secret.go
@@ -59,7 +59,7 @@ func (t *taskUpdateSecret) Run() {
 			continue
 		}
 
-		m, ok := vv.(map[string]interface{})
+		m, ok := vv.(map[string]any)
 		if !ok {
 			slog.Error("Error casting secret data to map[string]interface{}")
 			return

--- a/task_watcher_event.go
+++ b/task_watcher_event.go
@@ -54,10 +54,11 @@ func (t *taskWatcherEvent) handlePodDeleted() {
 	foundSecret := new(secret)
 	// Find the secret that matches the deleted secret
 	for _, s := range secrets {
-		if s.DestinationNamespace == obj.Namespace && s.DestinationName == obj.Name {
-			foundSecret = s
-			break
+		if s.DestinationNamespace != obj.Namespace || s.DestinationName != obj.Name {
+			continue
 		}
+		foundSecret = s
+		break
 	}
 	if foundSecret.Path == "" {
 		slog.Warn("Secret not found")

--- a/vault.go
+++ b/vault.go
@@ -14,7 +14,7 @@ import (
 func getVaultClient(v *viper.Viper) (*api.Client, error) {
 	addr := v.GetString("vault.address")
 	if addr == "" {
-		slog.Info("No vault address provided, using default address", slog.String("default_address", defaultVaultAddr))
+		slog.Info("No vault address provided, using default address", slog.String(loggingKeyAddr, defaultVaultAddr))
 		addr = defaultVaultAddr
 	}
 

--- a/vault.go
+++ b/vault.go
@@ -14,7 +14,7 @@ import (
 func getVaultClient(v *viper.Viper) (*api.Client, error) {
 	addr := v.GetString("vault.address")
 	if addr == "" {
-		slog.Info(fmt.Sprintf("No vault address provided, defaulting to %s", defaultVaultAddr))
+		slog.Info("No vault address provided, using default address", slog.String("default_address", defaultVaultAddr))
 		addr = defaultVaultAddr
 	}
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes various changes to improve code quality, enhance logging, and optimize performance. The most important changes are grouped by theme below:

### Code Quality Improvements:
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R1-R143): Enabled additional linters and configured their settings to enforce better coding practices.
* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L50): Removed the `only-new-issues` option to ensure all issues are checked.

### Logging Enhancements:
* [`context.go`](diffhunk://#diff-552f47512a00afe5fc6850cc9ddc830a6daeca162750e50aab4ed549685e0253L19-R19): Updated signal logging to use the `loggingKeySignal` constant.
* [`logging.go`](diffhunk://#diff-13982774527759915c2b53723c859945d5a30bab99be58a016650ce3f6b9f673L17-R25): Modified the `initializeLogger` function to use `slog.String` for logging attributes, ensuring consistency.
* [`vault.go`](diffhunk://#diff-948c5baf152b678d48780c18170df98c73fc95a770816c1053ef2e1f935bafaaL17-R17): Improved the log message for the default vault address to include the `loggingKeyAddr` constant.

### Performance Optimizations:
* [`sync.go`](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL81-R84): Updated the `syncSecrets` function to use pointers when iterating over namespaces to reduce memory usage.

### Security Enhancements:
* [`hashing.go`](diffhunk://#diff-0cbe42e0c7a2c123e4afe2577c02435c38cd6a384c3ccec1d3cd489eea55fcdfL4-R9): Switched from `sha1` to `sha256` for hashing to improve security.

### Code Consistency:
* `task_create_secret.go` and `task_update_secret.go`: Replaced `map[string]interface{}` with `map[string]any` for type consistency. [[1]](diffhunk://#diff-c366e7f8af7cf38b05644a7a7c11031135d9fb693920ae5a80922bea7b005060L69-R69) [[2]](diffhunk://#diff-ee415805de251d855cd4b9378b50d36c81dcd6f582007110127a6fb0c68c35e6L62-R62)