### PR TITLE
feat(cicd): adding additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,8 @@ linters:
     - iface
     - thelper
     - tparallel
+    - intrange
+    - testifylint
 issues:
   exclude-rules:
     - path: (.+)_test.go
@@ -141,3 +143,5 @@ linters-settings:
     enable:
       - identical # Identifies interfaces in the same package that have identical method sets.
       - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+  testifylint:
+    enable-all: true

--- a/sync.go
+++ b/sync.go
@@ -90,7 +90,7 @@ func (a *app) syncSecrets() {
 			})
 			if err != nil {
 				newErr := new(coreErr.StatusError)
-				if newErr.ErrStatus.Reason == metav1.StatusReasonNotFound && errors.As(err, &newErr) {
+				if errors.As(err, &newErr) && newErr.ErrStatus.Reason == metav1.StatusReasonNotFound { // nolint:revive // We need to cast see if the error is a StatusError before we can check the reason
 					// Secret does not exist in this namespace
 					continue
 				}

--- a/task_watcher_event.go
+++ b/task_watcher_event.go
@@ -10,8 +10,7 @@ import (
 
 type taskWatcherEvent struct {
 	event watch.Event
-
-	a *app
+	a     *app
 }
 
 func newTaskWatcherEvent(
@@ -30,14 +29,14 @@ func (t *taskWatcherEvent) Run() {
 		// Do nothing
 	case watch.Deleted:
 		slog.Debug("Secret deletion event")
-		t.handlePodDeleted()
+		t.handleDeletedSecret()
 	case watch.Error:
 		slog.Error("Watcher event error")
 	}
 }
 
-// handlePodDeleted recreates the secret when the secret is deleted
-func (t *taskWatcherEvent) handlePodDeleted() {
+// handleDeletedSecret recreates the secret when the secret is deleted
+func (t *taskWatcherEvent) handleDeletedSecret() {
 	// Find the secret from the config
 	secrets, err := t.a.getSecrets()
 	if err != nil {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to improve linting configuration and refactor error handling in the codebase. The most important changes include adding new linters to the `.golangci.yaml` configuration, enabling settings for the new linters, and refactoring error handling logic in the `syncSecrets` function. Additionally, there are minor refactorings in the `task_watcher_event.go` file to improve code clarity.

### Linting Configuration Improvements:

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R15-R16): Added `intrange` and `testifylint` linters to the configuration.
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R146-R147): Enabled all settings for the `testifylint` linter.

### Code Refactoring:

* [`sync.go`](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL93-R93): Refactored error handling logic in the `syncSecrets` function to check the error type before accessing its properties.
* [`task_watcher_event.go`](diffhunk://#diff-db881015f3d227514c285d79adf88e10d7f15737ba906d055ccb7942e363a187L33-R39): Renamed the `handlePodDeleted` function to `handleDeletedSecret` for better clarity and consistency with the event type.

### Minor Code Cleanup:

* [`task_watcher_event.go`](diffhunk://#diff-db881015f3d227514c285d79adf88e10d7f15737ba906d055ccb7942e363a187L13): Removed an unnecessary blank line in the `taskWatcherEvent` struct definition.