### PR TITLE
fix(app): general fixes

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -6,6 +6,7 @@ const (
 	loggingKeyError       = "err"
 	loggingKeyNamespace   = "namespace"
 	loggingKeyDestination = "destination"
+	loggingKeyInterval    = "interval"
 
 	secretAnnotationSyncIdKey = "vault-sync-id" // nolint:gosec // This is not a credential
 	secretLabelManagedBy      = "managed-by"

--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ func (a *App) Start() error {
 				return errors.New("invalid refresh interval")
 			}
 
+			a.base.Logger().Info("Interval set", slog.String(loggingKeyInterval, interval.String()))
+
 			a.config.syncInterval = interval
 			return nil
 		}),

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func (a *App) Start() error {
 			vip.OnConfigChange(func(e fsnotify.Event) {
 				a.base.Shutdown() // Restart the app on config change
 			})
+			go vip.WatchConfig()
 			return nil
 		}),
 		web.WithDependencyBootstrap(func(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 type (
 	AppConfig struct {
 		Secrets      []*Secret
-		syncInterval time.Duration
+		syncInterval *time.Duration
 	}
 
 	App struct {
@@ -82,7 +82,7 @@ func (a *App) Start() error {
 
 			a.base.Logger().Info("Interval set", slog.String(loggingKeyInterval, interval.String()))
 
-			a.config.syncInterval = interval
+			a.config.syncInterval = &interval
 			return nil
 		}),
 		web.WithIndefiniteAsyncTask("watch-secrets", watchSecrets(

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 type (
 	AppConfig struct {
 		Secrets      []*Secret
-		syncInterval *time.Duration
+		syncInterval time.Duration
 	}
 
 	App struct {
@@ -84,7 +84,7 @@ func (a *App) Start() error {
 
 			a.base.Logger().Info("Interval set", slog.String(loggingKeyInterval, interval.String()))
 
-			a.config.syncInterval = &interval
+			a.config.syncInterval = interval
 			return nil
 		}),
 		web.WithDependencyBootstrap(func(ctx context.Context) error {

--- a/secrets.go
+++ b/secrets.go
@@ -20,7 +20,7 @@ var (
 
 type Secret struct {
 	Mount                string            `mapstructure:"mount"`
-	Name                 string            `mapstructure:"path"`
+	Name                 string            `mapstructure:"name"`
 	DestinationNamespace string            `mapstructure:"destination_namespace"`
 	DestinationName      string            `mapstructure:"destination_name"`
 	Type                 corev1.SecretType `mapstructure:"type"` // Should be a Kubernetes Secret type

--- a/secrets.go
+++ b/secrets.go
@@ -12,31 +12,26 @@ import (
 )
 
 var (
-	ErrNoPath                 = errors.New("path is required")
+	ErrNoMount                = errors.New("mount is required")
+	ErrNoName                 = errors.New("name is required")
 	ErrNoDestinationNamespace = errors.New("destination_namespace is required")
 	ErrNoDestinationName      = errors.New("destination_name is required")
 )
 
 type Secret struct {
-	Path                 string            `mapstructure:"path"`
+	Mount                string            `mapstructure:"mount"`
+	Name                 string            `mapstructure:"path"`
 	DestinationNamespace string            `mapstructure:"destination_namespace"`
 	DestinationName      string            `mapstructure:"destination_name"`
 	Type                 corev1.SecretType `mapstructure:"type"` // Should be a Kubernetes Secret type
 }
 
-func NewSecret(path, destinationNamespace, destinationName string, secretType corev1.SecretType) *Secret {
-	return &Secret{
-		Path:                 path,
-		DestinationNamespace: destinationNamespace,
-		DestinationName:      destinationName,
-		Type:                 secretType,
-	}
-}
-
 func (s *Secret) Valid() error {
 	switch {
-	case s.Path == "":
-		return ErrNoPath
+	case s.Mount == "":
+		return ErrNoMount
+	case s.Name == "":
+		return ErrNoName
 	case s.DestinationNamespace == "":
 		return ErrNoDestinationNamespace
 	case s.DestinationName == "":

--- a/secrets.go
+++ b/secrets.go
@@ -75,6 +75,10 @@ func (s *Secret) Upsert(ctx context.Context, kubeClient kubernetes.Interface, va
 		}
 	}
 
+	if len(newSecret.Data) == 0 {
+		return errors.New("no data found in secret")
+	}
+
 	// Add an annotation with the hash of the Secret
 	hashBytes, err := json.Marshal(newSecret)
 	if err != nil {

--- a/secrets.go
+++ b/secrets.go
@@ -61,20 +61,8 @@ func (s *Secret) Upsert(ctx context.Context, kubeClient kubernetes.Interface, va
 
 	newSecret.Data = make(map[string][]byte)
 	for vk, vv := range value {
-		if vk != "data" {
-			continue
-		}
-
-		m, ok := vv.(map[string]any)
-		if !ok {
-			return fmt.Errorf("invalid value for key %s: %v", vk, vv)
-		}
-
-		for k, v := range m {
-			newSecret.Data[k] = []byte(fmt.Sprintf("%v", v))
-		}
+		newSecret.Data[vk] = []byte(fmt.Sprintf("%v", vv))
 	}
-
 	if len(newSecret.Data) == 0 {
 		return errors.New("no data found in secret")
 	}

--- a/sync.go
+++ b/sync.go
@@ -87,7 +87,7 @@ func deletedSecretHandler(
 		}
 
 		// Get the secret from vault
-		vaultSecret, err := vaultClient.Path(foundSecret.Path).GetKvSecretV2(ctx)
+		vaultSecret, err := vaultClient.Path(foundSecret.Name).GetKvSecretV2(ctx)
 		if err != nil {
 			l.Error("Error getting secret from vault", slog.String(loggingKeyError, err.Error()))
 			return
@@ -188,7 +188,10 @@ func syncSecrets(
 		}
 
 		// Get the secret from vault
-		vaultSecret, err := vaultClient.Path(secret.Path).GetKvSecretV2(ctx)
+		vaultSecret, err := vaultClient.Path(
+			secret.Name,
+			vaulty.WithMount(secret.Mount),
+		).GetKvSecretV2(ctx)
 		if err != nil {
 			l.Error("Error getting secret from vault", slog.String(loggingKeyError, err.Error()))
 			continue

--- a/sync.go
+++ b/sync.go
@@ -56,6 +56,12 @@ func deletedSecretHandler(
 			return
 		}
 
+		l = l.With(
+			slog.String(loggingKeyNamespace, secret.Namespace),
+			slog.String(loggingKeyDestination, secret.Name),
+		)
+		l.Debug("Secret deletion event received")
+
 		if !hashBucket.InBucket(secret.Name) {
 			return
 		}

--- a/sync.go
+++ b/sync.go
@@ -56,15 +56,15 @@ func deletedSecretHandler(
 			return
 		}
 
+		if !hashBucket.InBucket(secret.Name) {
+			return
+		}
+
 		l = l.With(
 			slog.String(loggingKeyNamespace, secret.Namespace),
 			slog.String(loggingKeyDestination, secret.Name),
 		)
 		l.Debug("Secret deletion event received")
-
-		if !hashBucket.InBucket(secret.Name) {
-			return
-		}
 
 		// Check if the secret is a vault secret
 		if secret.Labels[secretLabelManagedBy] != appName {

--- a/sync.go
+++ b/sync.go
@@ -103,16 +103,11 @@ func syncSecrets(
 	kubeClient kubernetes.Interface,
 	vaultClient vaulty.Client,
 	hashBucket cache.HashBucket,
-	interval *time.Duration,
+	interval time.Duration,
 	secrets []*Secret,
 ) web.AsyncTaskFunc {
 	return func(ctx context.Context) {
-		if interval == nil {
-			l.Error("Interval is nil")
-			return
-		}
-
-		ticker := time.NewTicker(*interval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
 		for {

--- a/sync.go
+++ b/sync.go
@@ -103,11 +103,16 @@ func syncSecrets(
 	kubeClient kubernetes.Interface,
 	vaultClient vaulty.Client,
 	hashBucket cache.HashBucket,
-	interval time.Duration,
+	interval *time.Duration,
 	secrets []*Secret,
 ) web.AsyncTaskFunc {
 	return func(ctx context.Context) {
-		ticker := time.NewTicker(interval)
+		if interval == nil {
+			l.Error("Interval is nil")
+			return
+		}
+
+		ticker := time.NewTicker(*interval)
 		defer ticker.Stop()
 
 		for {

--- a/sync.go
+++ b/sync.go
@@ -16,19 +16,23 @@ import (
 	kubeCache "k8s.io/client-go/tools/cache"
 )
 
-func watchSecrets(
+func (a *App) watchSecrets(
 	l *slog.Logger,
-	kubeClient kubernetes.Interface,
-	secretInformer kubeCache.SharedIndexInformer,
-	vaultClient vaulty.Client,
-	hashBucket cache.HashBucket,
-	secrets []*Secret,
 ) web.AsyncTaskFunc {
 	return func(ctx context.Context) {
+		secretInformer := a.base.SecretInformer()
+
 		if _, err := secretInformer.AddEventHandler(kubeCache.ResourceEventHandlerFuncs{
 			AddFunc:    nil,
 			UpdateFunc: nil,
-			DeleteFunc: deletedSecretHandler(ctx, l, kubeClient, vaultClient, hashBucket, secrets),
+			DeleteFunc: deletedSecretHandler(
+				ctx,
+				l,
+				a.base.KubeClient(),
+				a.base.VaultClient(),
+				a.base.ServiceEndpointHashBucket(),
+				a.config.Secrets,
+			),
 		}); err != nil {
 			l.Error("Error adding event handler", slog.String(loggingKeyError, err.Error()))
 			return
@@ -98,16 +102,11 @@ func deletedSecretHandler(
 }
 
 // All secrets will have the annotation of "vault-sync-id=hash" where hash is the hash of the path.
-func syncSecrets(
+func (a *App) syncSecretsTicker(
 	l *slog.Logger,
-	kubeClient kubernetes.Interface,
-	vaultClient vaulty.Client,
-	hashBucket cache.HashBucket,
-	interval time.Duration,
-	secrets []*Secret,
 ) web.AsyncTaskFunc {
 	return func(ctx context.Context) {
-		ticker := time.NewTicker(interval)
+		ticker := time.NewTicker(a.config.syncInterval)
 		defer ticker.Stop()
 
 		for {
@@ -116,70 +115,89 @@ func syncSecrets(
 				l.Info("Stopping secret sync")
 				return
 			case <-ticker.C:
-				namespaces, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-				if err != nil {
-					l.Error("Error listing namespaces", slog.String(loggingKeyError, err.Error()))
+				l.Debug("Syncing secrets")
+				syncSecrets(
+					ctx,
+					l,
+					a.base.KubeClient(),
+					a.base.VaultClient(),
+					a.base.ServiceEndpointHashBucket(),
+					a.config.Secrets,
+				)
+			}
+		}
+	}
+}
+
+func syncSecrets(
+	ctx context.Context,
+	l *slog.Logger,
+	kubeClient kubernetes.Interface,
+	vaultClient vaulty.Client,
+	hashBucket cache.HashBucket,
+	secrets []*Secret,
+) {
+	namespaces, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		l.Error("Error listing namespaces", slog.String(loggingKeyError, err.Error()))
+		return
+	}
+
+	for _, secret := range secrets {
+		if !hashBucket.InBucket(secret.DestinationName) {
+			continue
+		}
+
+		l = l.With(
+			slog.String(loggingKeyNamespace, secret.DestinationNamespace),
+			slog.String(loggingKeyDestination, secret.DestinationName),
+		)
+
+		if err := secret.Valid(); err != nil {
+			l.Error("Invalid secret", slog.String(loggingKeyError, err.Error()))
+			continue
+		}
+
+		for i := range namespaces.Items {
+			ns := &namespaces.Items[i]
+
+			// Does the secret exist in this namespace?
+			foundSecret, err := kubeClient.CoreV1().Secrets(ns.Name).Get(ctx, secret.DestinationName, metav1.GetOptions{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Secret",
+				},
+			})
+			if err != nil {
+				newErr := new(coreErr.StatusError)
+				if errors.As(err, &newErr) && newErr.ErrStatus.Reason == metav1.StatusReasonNotFound { // nolint:revive // We need to cast see if the error is a StatusError before we can check the reason
+					// Secret does not exist in this namespace
 					continue
 				}
 
-				for _, secret := range secrets {
-					if !hashBucket.InBucket(secret.DestinationName) {
-						continue
-					}
+				l.Error("Error getting secret", slog.String(loggingKeyError, err.Error()))
+				continue
+			} else if foundSecret.Namespace != secret.DestinationNamespace { // nolint:revive // We need to check if the secret is in the correct namespace
+				l.Info("Secret exists in a different namespace", slog.String(loggingKeyNamespace, foundSecret.Namespace))
 
-					l = l.With(
-						slog.String(loggingKeyNamespace, secret.DestinationNamespace),
-						slog.String(loggingKeyDestination, secret.DestinationName),
-					)
-
-					if err := secret.Valid(); err != nil {
-						l.Error("Invalid secret", slog.String(loggingKeyError, err.Error()))
-						continue
-					}
-
-					for i := range namespaces.Items {
-						ns := &namespaces.Items[i]
-
-						// Does the secret exist in this namespace?
-						foundSecret, err := kubeClient.CoreV1().Secrets(ns.Name).Get(ctx, secret.DestinationName, metav1.GetOptions{
-							TypeMeta: metav1.TypeMeta{
-								Kind: "Secret",
-							},
-						})
-						if err != nil {
-							newErr := new(coreErr.StatusError)
-							if errors.As(err, &newErr) && newErr.ErrStatus.Reason == metav1.StatusReasonNotFound { // nolint:revive // We need to cast see if the error is a StatusError before we can check the reason
-								// Secret does not exist in this namespace
-								continue
-							}
-
-							l.Error("Error getting secret", slog.String(loggingKeyError, err.Error()))
-							continue
-						} else if foundSecret.Namespace != secret.DestinationNamespace { // nolint:revive // We need to check if the secret is in the correct namespace
-							l.Info("Secret exists in a different namespace", slog.String(loggingKeyNamespace, foundSecret.Namespace))
-
-							// Delete the secret
-							if err := kubeClient.CoreV1().Secrets(ns.Name).Delete(ctx, foundSecret.Name, metav1.DeleteOptions{}); err != nil { // nolint:revive // Traditional error handling
-								l.Error("Error deleting secret", slog.String(loggingKeyError, err.Error()))
-								return
-							}
-						}
-					}
-
-					// Get the secret from vault
-					vaultSecret, err := vaultClient.Path(secret.Path).GetKvSecretV2(ctx)
-					if err != nil {
-						l.Error("Error getting secret from vault", slog.String(loggingKeyError, err.Error()))
-						continue
-					}
-
-					// Upsert the secret
-					if err := secret.Upsert(ctx, kubeClient, vaultSecret.Data); err != nil { // nolint:revive // Traditional error handling
-						l.Error("Error upserting secret", slog.String(loggingKeyError, err.Error()))
-						continue
-					}
+				// Delete the secret
+				if err := kubeClient.CoreV1().Secrets(ns.Name).Delete(ctx, foundSecret.Name, metav1.DeleteOptions{}); err != nil { // nolint:revive // Traditional error handling
+					l.Error("Error deleting secret", slog.String(loggingKeyError, err.Error()))
+					return
 				}
 			}
+		}
+
+		// Get the secret from vault
+		vaultSecret, err := vaultClient.Path(secret.Path).GetKvSecretV2(ctx)
+		if err != nil {
+			l.Error("Error getting secret from vault", slog.String(loggingKeyError, err.Error()))
+			continue
+		}
+
+		// Upsert the secret
+		if err := secret.Upsert(ctx, kubeClient, vaultSecret.Data); err != nil { // nolint:revive // Traditional error handling
+			l.Error("Error upserting secret", slog.String(loggingKeyError, err.Error()))
+			continue
 		}
 	}
 }

--- a/sync.go
+++ b/sync.go
@@ -93,7 +93,10 @@ func deletedSecretHandler(
 		}
 
 		// Get the secret from vault
-		vaultSecret, err := vaultClient.Path(foundSecret.Name).GetKvSecretV2(ctx)
+		vaultSecret, err := vaultClient.Path(
+			foundSecret.Name,
+			vaulty.WithMount(foundSecret.Mount),
+		).GetKvSecretV2(ctx)
 		if err != nil {
 			l.Error("Error getting secret from vault", slog.String(loggingKeyError, err.Error()))
 			return


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to improve the logging, configuration handling, and secret management in the application. The most important changes include adding new logging keys, updating the configuration handling to watch for changes, modifying secret management to use `Mount` and `Name` instead of `Path`, and refactoring the `watchSecrets` and `syncSecrets` functions.

### Logging improvements:
* Added a new logging key `loggingKeyInterval` to `consts.go` for better logging of intervals.
* Enhanced logging in the `deletedSecretHandler` function to include namespace and destination details and added a debug log for secret deletion events in `sync.go`. [[1]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeR63-R68) [[2]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL86-R99)

### Configuration handling:
* Updated the `Start` function in `main.go` to watch for configuration changes using `vip.WatchConfig()`.
* Added logging for the interval setting in the `Start` function in `main.go`.

### Secret management:
* Modified `secrets.go` to use `Mount` and `Name` instead of `Path` for secrets and added corresponding error messages.
* Refactored the `Upsert` function in `secrets.go` to handle secret data more efficiently and added a check for empty secret data.

### Refactoring:
* Refactored the `watchSecrets` function in `sync.go` to use instance variables from the `App` struct.
* Refactored the `syncSecrets` function in `sync.go` to use a ticker for periodic syncing and added a new `syncSecrets` helper function. [[1]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL101-R118) [[2]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeR127-R152) [[3]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL170-R203) [[4]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL183-L185)